### PR TITLE
Bump mackerel-agent v0.19.0 and mkr v0.3.1

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -1,12 +1,12 @@
 class MackerelAgent < Formula
   homepage 'https://github.com/mackerelio/mackerel-agent'
-  version '0.20.0'
+  version '0.20.1'
   if Hardware.is_64_bit?
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.0/mackerel-agent_darwin_amd64.zip'
-    sha256 '6f44f012500babf59dcc95761a0192528aec084ae95b9bf058654b88a7c9330c'
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.1/mackerel-agent_darwin_amd64.zip'
+    sha256 'ce375362cab4412e88047a22d1847e7a6b8cf613b75faf6784bdbd016261159a'
   else
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.0/mackerel-agent_darwin_386.zip'
-    sha256 'bab75180baaaf4190b3dcc78cd623e92fd70e6f6ec4fcc9426cb5f08981bc399'
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.1/mackerel-agent_darwin_386.zip'
+    sha256 '6774188025fb32755e20757828739c60a9f7121738470fd728462f3b7f4c1bcc'
   end
 
   head do

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,12 +1,12 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
-  version '0.3.1'
+  version '0.4.0'
   if Hardware.is_64_bit?
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.3.1/mkr_darwin_amd64.zip'
-    sha256 '5de62574771738a5d6ed7fdd25883b2e9dc97ab0ffec7c65c644c175f0ecbb42'
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.0/mkr_darwin_amd64.zip'
+    sha256 '83c20e6b6811423426c5edaabf6676d74489cc817a7b85c897f6ecd102d82ab2'
   else
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.3.1/mkr_darwin_386.zip'
-    sha256 '91e2b9e9d7c39077a22be83e2f36bcd5d4e98a04da4d4cf16e729d6e751da5aa'
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.0/mkr_darwin_386.zip'
+    sha256 '76596331bedfdd16ec1f34e213e6cd08a2ca01643356dc5db3258f8fe77d6693'
   end
 
   head do


### PR DESCRIPTION
- mackerel-agent: https://github.com/mackerelio/mackerel-agent/releases/tag/v0.20.1
- mkr: https://github.com/mackerelio/mkr/releases/tag/v0.4.0
