### PR TITLE
bump version to 0.22.0 (agent)  / 0.4.1 (mkr)

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -1,12 +1,12 @@
 class MackerelAgent < Formula
   homepage 'https://github.com/mackerelio/mackerel-agent'
-  version '0.20.1'
+  version '0.22.0'
   if Hardware.is_64_bit?
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.1/mackerel-agent_darwin_amd64.zip'
-    sha256 'ce375362cab4412e88047a22d1847e7a6b8cf613b75faf6784bdbd016261159a'
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.22.0/mackerel-agent_darwin_amd64.zip'
+    sha256 '57cc1396f22aef7037f7de39733f2a1cb342a042e4117713338c0bdccaccbaa7'
   else
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.20.1/mackerel-agent_darwin_386.zip'
-    sha256 '6774188025fb32755e20757828739c60a9f7121738470fd728462f3b7f4c1bcc'
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.22.0/mackerel-agent_darwin_386.zip'
+    sha256 'b18259f38da86172c80a0d9d45d1505dd586c5a3427b27b72e1a5fbfee02525e'
   end
 
   head do

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,12 +1,12 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
-  version '0.4.0'
+  version '0.4.1'
   if Hardware.is_64_bit?
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.0/mkr_darwin_amd64.zip'
-    sha256 '83c20e6b6811423426c5edaabf6676d74489cc817a7b85c897f6ecd102d82ab2'
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.1/mkr_darwin_amd64.zip'
+    sha256 '34d5f6f9d01e7f1813b6c584d81ec8e703de3d6c7837062e0f068be74ac85e37'
   else
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.0/mkr_darwin_386.zip'
-    sha256 '76596331bedfdd16ec1f34e213e6cd08a2ca01643356dc5db3258f8fe77d6693'
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.4.1/mkr_darwin_386.zip'
+    sha256 '7a48a9d1ac57e93bc4caa5e86594509ffaec64201a759b8b15d332c2896e53f1'
   end
 
   head do


### PR DESCRIPTION
## summary
- Changes for mac is nothing...
## binaries
- mackerel-agent:
  - https://github.com/mackerelio/mackerel-agent/releases/tag/v0.21.0
  - https://github.com/mackerelio/mackerel-agent/releases/tag/v0.22.0
- mkr
  - https://github.com/mackerelio/mkr/releases/tag/v0.4.1
