### PR TITLE
Use Hardware::CPU.is_64_bit? instead of Hardware.is_64_bit?

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -1,7 +1,7 @@
 class MackerelAgent < Formula
   homepage 'https://github.com/mackerelio/mackerel-agent'
   version '0.32.2'
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.32.2/mackerel-agent_darwin_amd64.zip'
     sha256 'a8c12efdd18e8f0a97653f3a3435cd730fcba929db107a73196c34a7f387b764'
   else

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,7 +1,7 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
   version '0.11.3'
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url 'https://github.com/mackerelio/mkr/releases/download/v0.11.3/mkr_darwin_amd64.zip'
     sha256 'bd29ec6c00266319e28767cd4c442a5b8385f78774c68e8853cce7512687b24c'
   else


### PR DESCRIPTION
`Hardware.is_64_bit?` is deprecated. Use `Hardware::CPU.is_64_bit?` instead.

```
$ brew info mkr
Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
/usr/local/Library/Taps/mackerelio/homebrew-mackerel-agent/mkr.rb:4:in `<class:Mkr>'

mackerelio/mackerel-agent/mkr: stable 0.11.3, HEAD
https://github.com/mackerelio/mkr
/usr/local/Cellar/mkr/0.11.3 (3 files, 10.5M) *
  Built from source on 2016-07-15 at 15:40:20
From: https://github.com/mackerelio/homebrew-mackerel-agent/blob/master/mkr.rb
```
