### PR TITLE
stop providing 32bit binaries

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -1,13 +1,8 @@
 class MackerelAgent < Formula
   homepage 'https://github.com/mackerelio/mackerel-agent'
   version '0.63.0'
-  if Hardware::CPU.is_64_bit?
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.63.0/mackerel-agent_darwin_amd64.zip'
-    sha256 '4f1146b5a2561cb993096ba02253ed05301fb2141422b929fb9e8bb8f0989beb'
-  else
-    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.63.0/mackerel-agent_darwin_386.zip'
-    sha256 '7ba5e2439f9ac232762344e17fd6ebae020acbb30682173c60c9328373a41497'
-  end
+  url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.63.0/mackerel-agent_darwin_amd64.zip'
+  sha256 '4f1146b5a2561cb993096ba02253ed05301fb2141422b929fb9e8bb8f0989beb'
 
   head do
     url 'https://github.com/mackerelio/mackerel-agent.git'

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,13 +1,8 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
   version '0.39.2'
-  if Hardware::CPU.is_64_bit?
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.39.2/mkr_darwin_amd64.zip'
-    sha256 '00adabd7fd98f66e5649b3944a4ad7255e171abb5906f010d24a6e078858e52f'
-  else
-    url 'https://github.com/mackerelio/mkr/releases/download/v0.39.2/mkr_darwin_386.zip'
-    sha256 '9c934a3f3123469f487c53fa728b86e8ccc27ae890e1d628d638a3489c926580'
-  end
+  url 'https://github.com/mackerelio/mkr/releases/download/v0.39.2/mkr_darwin_amd64.zip'
+  sha256 '00adabd7fd98f66e5649b3944a4ad7255e171abb5906f010d24a6e078858e52f'
 
   head do
     url 'https://github.com/mackerelio/mkr.git'


### PR DESCRIPTION
From following reason, I'd like to remove 32bit binaries from the formulas:
- The last Mac OS X version to support 32-bit was Snow Leopard, which is an ancient one
  - Golang has already dropped supporting those old versions
- Homebrew drops 32-bit support at [1.9.0 on January 2019](https://brew.sh/2019/01/09/homebrew-1.9.0/)