### PR TITLE
add -private-autoshutdown option

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -47,6 +47,7 @@ class MackerelAgent < Formula
          <string>supervise</string>
          <string>-conf</string>
          <string>#{etc}/mackerel-agent.conf</string>
+         <string>-private-autoshutdown</string>
      </array>
      <key>RunAtLoad</key>
      <true/>


### PR DESCRIPTION
To fix *exec(2)* problem, I added `-private-autoshutdown` to plist.

ref mackerelio/mackerel-agent#612

Though I considered to use `Formula#post_install`, it couldn't because Homebrew runs a Formula in sandbox.