### PR TITLE
Supports arm64 native builds

### DIFF
--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -1,8 +1,13 @@
 class MackerelAgent < Formula
   homepage 'https://github.com/mackerelio/mackerel-agent'
   version '0.72.5'
-  url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.72.5/mackerel-agent_darwin_amd64.zip'
-  sha256 'f81f48557fa0b51afcbaa6b10176e578bdee63f1a4d21d06bb48720ce342c064'
+  if Hardware::CPU.arm?
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.72.5/mackerel-agent_darwin_arm64.zip'
+    sha256 '518f2d853072ea5e445ada6adc5f5c11506e735d184f152af7529193422508b0'
+  else
+    url 'https://github.com/mackerelio/mackerel-agent/releases/download/v0.72.5/mackerel-agent_darwin_amd64.zip'
+    sha256 'f81f48557fa0b51afcbaa6b10176e578bdee63f1a4d21d06bb48720ce342c064'
+  end
 
   head do
     url 'https://github.com/mackerelio/mackerel-agent.git'

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,7 +1,7 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
   version '0.46.0'
-  if Hardware::CPU.physical_cpu_arm64? && !Hardware::CPU.in_rosetta2?
+  if Hardware::CPU.arm?
     url 'https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_arm64.zip'
     sha256 '2dc4e2bb93abcc6ca3a6e1582cf022ab8df69201f070f260c7849e2a95618063'
   else

--- a/mkr.rb
+++ b/mkr.rb
@@ -1,8 +1,13 @@
 class Mkr < Formula
   homepage 'https://github.com/mackerelio/mkr'
   version '0.46.0'
-  url 'https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_amd64.zip'
-  sha256 '8e013543b9fc51b0d09bf1cccf4f3a4d3f8e3546c1ec0fed31228b62dc319b55'
+  if Hardware::CPU.physical_cpu_arm64? && !Hardware::CPU.in_rosetta2?
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_arm64.zip'
+    sha256 '2dc4e2bb93abcc6ca3a6e1582cf022ab8df69201f070f260c7849e2a95618063'
+  else
+    url 'https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_amd64.zip'
+    sha256 '8e013543b9fc51b0d09bf1cccf4f3a4d3f8e3546c1ec0fed31228b62dc319b55'
+  end
 
   head do
     url 'https://github.com/mackerelio/mkr.git'


### PR DESCRIPTION
Uses [`Hardware::CPU.arm?`](https://rubydoc.brew.sh/Hardware/CPU.html#arm%3F-class_method) to detect whether target machine is ARM or not.

Historically these formulas supported 32bit (dropped at #25), and therefore `./tools/update.rb` works even if there're multiple urls. (In fact I used the script to fill-in sha256 hashes)

## demo

On my M1Pro MBP:
```
[github.com/mackerelio/homebrew-mackerel-agent]$ brew install --formula ./mkr.rb
==> Downloading https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_arm64.zip
Already downloaded: /Users/asato/Library/Caches/Homebrew/downloads/1bd5ffe230a8fe7b997b4c2d6674e693e12e30826c5734246047517a0695d1ec--mkr_darwin_arm64.zip
🍺  /opt/homebrew/Cellar/mkr/0.46.0: 6 files, 8.4MB, built in 1 second
==> Running `brew cleanup mkr`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
[github.com/mackerelio/homebrew-mackerel-agent]$ file /opt/homebrew/bin/mkr
/opt/homebrew/bin/mkr: Mach-O 64-bit executable arm64
```
```
[github.com/mackerelio/homebrew-mackerel-agent]$ brew install --formula ./mackerel-agent.rb
==> Downloading https://github.com/mackerelio/mackerel-agent/releases/download/v0.72.5/mackerel-agent_darw
==> Downloading from https://github-releases.githubusercontent.com/19845168/c92056c7-56a8-47aa-bd6d-37fc7d
######################################################################## 100.0%
==> Caveats
You must append `apikey = {apikey}` configuration variable to /opt/homebrew/etc/mackerel-agent.conf
in order for mackerel-agent to work.

To start mackerel-agent now and restart at login:
  brew services start mackerel-agent
Or, if you don't want/need a background service you can just run:
  mackerel-agent -conf /opt/homebrew/etc/mackerel-agent.conf
==> Summary
🍺  /opt/homebrew/Cellar/mackerel-agent/0.72.5: 8 files, 7.4MB, built in 1 second
==> Running `brew cleanup mackerel-agent`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
[github.com/mackerelio/homebrew-mackerel-agent]$ file /opt/homebrew/bin/mackerel-agent
/opt/homebrew/bin/mackerel-agent: Mach-O 64-bit executable arm64
```

On my Intel MBP installing `mkr` (omitted `mackerel-agent` simply because I don't want to uninstall it..)
```
[github.com/mackerelio/homebrew-mackerel-agent]$ brew install --formula ./mkr.rb
==> Downloading https://github.com/mackerelio/mkr/releases/download/v0.46.0/mkr_darwin_amd64.zip
==> Downloading from https://github-releases.githubusercontent.com/25763415/7e97fec7-e1e2-4aa0-b13b-e51868fbb4d8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20211202%2Fus-east-1%2Fs3%2Faws4_req
######################################################################## 100.0%
🍺  /usr/local/Cellar/mkr/0.46.0: 6 files, 8.6MB, built in 3 seconds
==> Running `brew cleanup mkr`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
[github.com/mackerelio/homebrew-mackerel-agent]$ file /usr/local/bin/mkr
/usr/local/bin/mkr: Mach-O 64-bit executable x86_64
```