### PR TITLE
Introduce CI, fix broken tests, and fix `brew install --HEAD mackerel-agent`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -48,7 +48,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: Formula
+
+on:
+  - push
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        formula:
+          - mkr
+          - mackerel-agent
+    steps:
+      # https://github.com/Homebrew/actions/tree/master/setup-homebrew
+      # This will clone this repo into $(brew --repo "$GITHUB_REPOSITORY")
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+      - name: Install the Formula
+        run: brew install ${{ github.repository }}/${{ matrix.formula }}
+        shell: bash
+      - name: Test the Formula
+        run: brew test ${{ github.repository }}/${{ matrix.formula }}
+        shell: bash
+  test-HEAD:
+    name: test (HEAD)
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        formula:
+          - mkr
+          - mackerel-agent
+    steps:
+      # https://github.com/Homebrew/actions/tree/master/setup-homebrew
+      # This will clone this repo into $(brew --repo "$GITHUB_REPOSITORY")
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+      # there may be go@1.x installed and it conflicts with go
+      - name: Preinstall go
+        run: brew install go || brew link --overwrite go
+      - name: Install the Formula with --HEAD
+        run: brew install --HEAD ${{ github.repository }}/${{ matrix.formula }}
+        shell: bash
+      - name: Test the Formula
+        run: brew test ${{ github.repository }}/${{ matrix.formula }}
+        shell: bash

--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -32,7 +32,7 @@ class MackerelAgent < Formula
   end
 
   test do
-    system 'mackerel-agent', '-version'
+    system 'mackerel-agent', 'version'
   end
 
   plist_options :manual => "mackerel-agent -conf #{HOMEBREW_PREFIX}/etc/mackerel-agent.conf"

--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -23,7 +23,7 @@ class MackerelAgent < Formula
       ln_s buildpath, buildpath/'.go/src/github.com/mackerelio/mackerel-agent'
       system 'make', 'build'
       bin.install 'build/mackerel-agent'
-      etc.install 'mackerel-agent.conf'
+      etc.install 'mackerel-agent.sample.conf' => 'mackerel-agent.conf'
     else
       bin.install 'mackerel-agent'
       etc.install 'mackerel-agent.conf'

--- a/mackerel-agent.rb
+++ b/mackerel-agent.rb
@@ -18,9 +18,6 @@ class MackerelAgent < Formula
 
   def install
     if build.head?
-      ENV['GOPATH'] = buildpath/'.go'
-      mkdir_p buildpath/'.go/src/github.com/mackerelio'
-      ln_s buildpath, buildpath/'.go/src/github.com/mackerelio/mackerel-agent'
       system 'make', 'build'
       bin.install 'build/mackerel-agent'
       etc.install 'mackerel-agent.sample.conf' => 'mackerel-agent.conf'

--- a/mkr.rb
+++ b/mkr.rb
@@ -18,9 +18,6 @@ class Mkr < Formula
 
   def install
     if build.head?
-      ENV['GOPATH'] = buildpath/'.go'
-      mkdir_p buildpath/'.go/src/github.com/mackerelio'
-      ln_s buildpath, buildpath/'.go/src/github.com/mackerelio/mkr'
       system 'make', 'build'
       bin.install 'mkr'
     else


### PR DESCRIPTION
Mainly this p-r introduces GitHub Actions CI for brew Formulae, and fixes Formulae a little to make tests pass.

In fact I also have `brew audit` CI in my fork (see https://github.com/astj/homebrew-mackerel-agent/pull/2 ), but for now I'd like not to introduce it since it might be "too much".
If you think `brew audit`ing is useful (and welcome big fixes like https://github.com/astj/homebrew-mackerel-agent/pull/3/files due to RuboCop 🤖 rewriting single quotes to double quotes), please tell me and I'll update this p-r to include `brew audit`.